### PR TITLE
Replace accidental comma with semicolon

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -32,7 +32,7 @@ export default class LFMBase {
 			offset: 0
 		};
 
-		newParams.num_res = params?.limit || 50,
+		newParams.num_res = params?.limit || 50;
 		newParams.offset = ((params?.page || 1) - 1) * newParams.num_res;
 		return newParams;
 	}


### PR DESCRIPTION
Came up when testing own build.
Code is only used in getTopTags.